### PR TITLE
Remove failing user ID sanity check on DPS Payment callback

### DIFF
--- a/modules/dps_payment_express/return.php
+++ b/modules/dps_payment_express/return.php
@@ -26,11 +26,15 @@ if( (bool) $transaction->attribute( 'success' ) ) {
 }
 
 if( eZUser::currentUserID() != $transaction->attribute( 'user_id' ) ) {
-	return $Params['Module']->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
+	$actualUserId = eZUser::currentUserID();
+	$orderUserId = $transaction->attribute( 'user_id' );
+	$logger->writeTimedString("Currently logged in user does not match expected user ID (from table dps_payment_express_transactions). Actual user: $actualUserId; Expected User: $orderUserId");
+    // return $Params['Module']->handleError( eZError::KERNEL_ACCESS_DENIED, 'kernel' );
 }
 
 $http = eZHTTPTool::instance();
 if( $http->hasGetVariable( 'result' ) === false ) {
+	$logger->writeTimedString("Callback is missing 'result' GET parameter. Aborting.");
 	return $Params['Module']->handleError( eZError::KERNEL_NOT_FOUND, 'kernel' );
 }
 


### PR DESCRIPTION
As discussed in email. 

Added more logging to DPS callback to try and clarify which failure cases are *actually* happening in response to DPS callbacks.

Removed user_id sanity check in DPS callback, as it seems to be kicking out legitimate users if they call out to DPS from one node, but are called back after payment and happen to land on the other node.